### PR TITLE
Update setup.py with working dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     "torch",
     "h5py",
     "numpy",
-    "overrides",
+    "overrides==1.9",
   ],
   classifiers=[
     "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
New versions of `overrides` cause an error on import; version 1.9 works as intended, so it should be required explicitly to prevent issues. See issue #5.